### PR TITLE
[-] MO : blocktopmenu: fixed bug when editing links labels with special ...

### DIFF
--- a/blocktopmenu.php
+++ b/blocktopmenu.php
@@ -1232,6 +1232,11 @@ class Blocktopmenu extends Module
 		if (Tools::isSubmit('updatelinksmenutop'))
 		{
 			$link = MenuTopLinks::getLinkLang(Tools::getValue('id_linksmenutop'), (int)Shop::getContextShopID());
+
+			array_walk($link['label'], function(&$value) {
+				$value = Tools::htmlentitiesDecodeUTF8(Tools::htmlentitiesDecodeUTF8($value));
+			});
+
 			$links_label_edit = $link['link'];
 			$labels_edit = $link['label'];
 			$new_window_edit = $link['new_window'];


### PR DESCRIPTION
Fixes a bug that occurs when editing links' labels that contain special characters (like óöñ...)

To reproduce bug:
1. Create a link containing special chars
   ![captura de pantalla 2014-08-21 a la s 19 42 19](https://cloud.githubusercontent.com/assets/389613/4000549/d3301316-295a-11e4-98f2-bd649751e095.png)
2. Click on modify
   ![captura de pantalla 2014-08-21 a la s 19 42 40](https://cloud.githubusercontent.com/assets/389613/4000554/e05e00de-295a-11e4-9089-72465f6338a4.png)
3. And you get a lot of HTML entities that will appear on frontend
   ![captura de pantalla 2014-08-21 a la s 19 42 51](https://cloud.githubusercontent.com/assets/389613/4000559/ee1f027c-295a-11e4-82a8-88f3c6921d3c.png)
