### PR TITLE
[*] blocktopmenu: mark all parent li as sfHoverForce

### DIFF
--- a/js/blocktopmenu.js
+++ b/js/blocktopmenu.js
@@ -1,0 +1,3 @@
+jQuery(function() {
+    jQuery('ul.sf-menu .sfHoverForce').parentsUntil('ul.sf-menu', 'li').addClass('sfHoverForce');
+});


### PR DESCRIPTION
that way the top menu glows as selected