### PR TITLE
Remove redefinition of parameter $id_shop in getCMSPages()

### DIFF
--- a/blocktopmenu.php
+++ b/blocktopmenu.php
@@ -802,7 +802,7 @@ class Blocktopmenu extends Module
 
 	}
 
-	protected function getCMSPages($id_cms_category, $id_shop = false, $id_lang = false, $id_shop = false)
+	protected function getCMSPages($id_cms_category, $id_shop = false, $id_lang = false)
 	{
 		$id_shop = ($id_shop !== false) ? (int)$id_shop : (int)Context::getContext()->shop->id;
 		$id_lang = $id_lang ? (int)$id_lang : (int)Context::getContext()->language->id;


### PR DESCRIPTION
Remove duplicate definition of $id_shop in the getCMSPages() function. PHP7 will not accept this and returns a fatal error upon encountering this.
