### PR TITLE
Make generateCategoriesMenu() a public function rather than protected

### DIFF
--- a/blocktopmenu.php
+++ b/blocktopmenu.php
@@ -590,7 +590,7 @@ class Blocktopmenu extends Module
         return $html;
     }
 
-    protected function generateCategoriesMenu($categories, $is_children = 0)
+    public function generateCategoriesMenu($categories, $is_children = 0)
     {
         $html = '';
 


### PR DESCRIPTION
Since it's useful because someone (other module, theme, ...) could use it to display
a custom category tree starting at a given level and benefit from the presentation,
consistency and work already done here.

Eg:
> require_once("modules/blocktopmenu/blocktopmenu.php");
> $cat = Category::getNestedCategories($root, 1, false, 1);
> $b = new Blocktopmenu();
> echo ($b->generateCategoriesMenu($cat));