### PR TITLE
Composite data structure

### DIFF
--- a/blocktopmenu.php
+++ b/blocktopmenu.php
@@ -25,12 +25,16 @@
 */
 
 require(dirname(__FILE__).'/menutoplinks.class.php');
+require(dirname(__FILE__).'/src/BlocktopmenuNode.php');
+require(dirname(__FILE__).'/src/BlocktopmenuNodeVisitor.php');
+require(dirname(__FILE__).'/src/SuperfishNodeVisitor.php');
 
 class Blocktopmenu extends Module
 {
     protected $_menu = '';
     protected $_html = '';
     protected $user_groups;
+    protected $items;
 
     /*
      * Pattern for matching config values
@@ -467,6 +471,8 @@ class Blocktopmenu extends Module
         $id_lang = (int)$this->context->language->id;
         $id_shop = (int)Shop::getContextShopID();
 
+        $items = array();
+
         foreach ($menu_items as $item) {
             if (!$item) {
                 continue;
@@ -477,47 +483,86 @@ class Blocktopmenu extends Module
 
             switch (substr($item, 0, strlen($value[1]))) {
                 case 'CAT':
-                    $this->_menu .= $this->generateCategoriesMenu(Category::getNestedCategories($id, $id_lang, false, $this->user_groups));
+                    $categories = Category::getNestedCategories($id, $id_lang, false, $this->user_groups);
+                    if ($category = current($categories)) {
+                        $categoryNode = $this->createCategoryNode($category, true);
+                        $items[] = $categoryNode;
+                        // Backward compatibility
+                        $legacyOutput = $this->generateCategoriesMenu($categories);
+                        if (!empty($legacyOutput)) {
+                            $this->_menu .= $legacyOutput;
+                        } else {
+                            $this->_menu .= self::renderNode($categoryNode);
+                        }
+                    }
                     break;
 
                 case 'PRD':
                     $selected = ($this->page_name == 'product' && (Tools::getValue('id_product') == $id)) ? ' class="sfHover"' : '';
                     $product = new Product((int)$id, true, (int)$id_lang);
                     if (!is_null($product->id)) {
-                        $this->_menu .= '<li'.$selected.'><a href="'.Tools::HtmlEntitiesUTF8($product->getLink()).'" title="'.$product->name.'">'.$product->name.'</a></li>'.PHP_EOL;
+                        $productNode = self::createNode(BlocktopmenuNode::TYPE_PRODUCT, array(
+                            'name' => $product->name,
+                            'link' => Tools::HtmlEntitiesUTF8($product->getLink()),
+                        ));
+                        $productNode->setSelected($selected);
+                        $items[] = $productNode;
+                        $this->_menu .= self::renderNode($productNode);
                     }
                     break;
 
                 case 'CMS':
-                    $selected = ($this->page_name == 'cms' && (Tools::getValue('id_cms') == $id)) ? ' class="sfHover"' : '';
+                    $selected = $this->page_name == 'cms' && Tools::getValue('id_cms') == $id;
                     $cms = CMS::getLinks((int)$id_lang, array($id));
-                    if (count($cms)) {
-                        $this->_menu .= '<li'.$selected.'><a href="'.Tools::HtmlEntitiesUTF8($cms[0]['link']).'" title="'.Tools::safeOutput($cms[0]['meta_title']).'">'.Tools::safeOutput($cms[0]['meta_title']).'</a></li>'.PHP_EOL;
+                    if (count($cms) == 1) {
+                        $cmsNode = self::createNode(BlocktopmenuNode::TYPE_CMS, array(
+                            'name' => Tools::safeOutput($cms[0]['meta_title']),
+                            'link' => Tools::HtmlEntitiesUTF8($cms[0]['link']),
+                        ));
+                        $cmsNode->setSelected($selected);
+                        $items[] = $manufacturersNode;
+                        $this->_menu .= self::renderNode($productNode);
                     }
                     break;
 
                 case 'CMS_CAT':
                     $category = new CMSCategory((int)$id, (int)$id_lang);
-                    if (count($category)) {
-                        $this->_menu .= '<li><a href="'.Tools::HtmlEntitiesUTF8($category->getLink()).'" title="'.$category->name.'">'.$category->name.'</a>';
+                    if (!is_null($category->id)) {
+                        $cmsCategoryNode = $this->createCmsCategoryNode($category);
+                        $items[] = $cmsCategoryNode;
+                        // Backward compatibility
+                        $tmp = $this->_menu;
+                        $this->_menu = '';
                         $this->getCMSMenuItems($category->id);
-                        $this->_menu .= '</li>'.PHP_EOL;
+                        if (!empty($this->_menu)) {
+                            $this->_menu = $tmp.'<li><a href="'.Tools::HtmlEntitiesUTF8($category->getLink()).'" title="'.$category->name.'">'.$category->name.'</a>'.$this->_menu.'</li>';
+                        } else {
+                            $this->_menu = $tmp.self::renderNode($cmsCategoryNode);
+                        }
                     }
                     break;
 
                 // Case to handle the option to show all Manufacturers
                 case 'ALLMAN':
                     $link = new Link;
-                    $this->_menu .= '<li><a href="'.$link->getPageLink('manufacturer').'" title="'.$this->l('All manufacturers').'">'.$this->l('All manufacturers').'</a><ul>'.PHP_EOL;
+                    $manufacturersNode = self::createNode(BlocktopmenuNode::TYPE_MANUFACTURERS, array(
+                        'link' => $link->getPageLink('manufacturer'),
+                        'name' => $this->l('All manufacturers'),
+                    ));
                     $manufacturers = Manufacturer::getManufacturers();
                     foreach ($manufacturers as $key => $manufacturer) {
-                        $this->_menu .= '<li><a href="'.$link->getManufacturerLink((int)$manufacturer['id_manufacturer'], $manufacturer['link_rewrite']).'" title="'.Tools::safeOutput($manufacturer['name']).'">'.Tools::safeOutput($manufacturer['name']).'</a></li>'.PHP_EOL;
+                        $manufacturerNode = self::createNode(BlocktopmenuNode::TYPE_MANUFACTURER, array(
+                            'link' => $link->getManufacturerLink((int)$manufacturer['id_manufacturer'], $manufacturer['link_rewrite']),
+                            'name' => Tools::safeOutput($manufacturer['name']),
+                        ));
+                        $manufacturersNode->addChild($manufacturerNode);
                     }
-                    $this->_menu .= '</ul>';
+                    $items[] = $manufacturersNode;
+                    $this->_menu .= self::renderNode($manufacturersNode);
                     break;
 
                 case 'MAN':
-                    $selected = ($this->page_name == 'manufacturer' && (Tools::getValue('id_manufacturer') == $id)) ? ' class="sfHover"' : '';
+                    $selected = ($this->page_name == 'manufacturer' && Tools::getValue('id_manufacturer') == $id);
                     $manufacturer = new Manufacturer((int)$id, (int)$id_lang);
                     if (!is_null($manufacturer->id)) {
                         if (intval(Configuration::get('PS_REWRITING_SETTINGS'))) {
@@ -526,50 +571,82 @@ class Blocktopmenu extends Module
                             $manufacturer->link_rewrite = 0;
                         }
                         $link = new Link;
-                        $this->_menu .= '<li'.$selected.'><a href="'.Tools::HtmlEntitiesUTF8($link->getManufacturerLink((int)$id, $manufacturer->link_rewrite)).'" title="'.Tools::safeOutput($manufacturer->name).'">'.Tools::safeOutput($manufacturer->name).'</a></li>'.PHP_EOL;
+                        $manufacturerNode = self::createNode(BlocktopmenuNode::TYPE_MANUFACTURER, array(
+                            'link' => $link->getManufacturerLink((int)$id, $manufacturer->link_rewrite),
+                            'name' => Tools::safeOutput($manufacturer['name']),
+                        ));
+                        $manufacturerNode->setSelected($selected);
+                        $items[] = $manufacturerNode;
+                        $this->_menu .= self::renderNode($manufacturersNode);
                     }
                     break;
 
                 // Case to handle the option to show all Suppliers
                 case 'ALLSUP':
                     $link = new Link;
-                    $this->_menu .= '<li><a href="'.$link->getPageLink('supplier').'" title="'.$this->l('All suppliers').'">'.$this->l('All suppliers').'</a><ul>'.PHP_EOL;
+                    $suppliersNode = self::createNode(BlocktopmenuNode::TYPE_MANUFACTURER, array(
+                        'link' => $link->getPageLink('supplier'),
+                        'name' => $this->l('All suppliers'),
+                    ));
                     $suppliers = Supplier::getSuppliers();
                     foreach ($suppliers as $key => $supplier) {
-                        $this->_menu .= '<li><a href="'.$link->getSupplierLink((int)$supplier['id_supplier'], $supplier['link_rewrite']).'" title="'.Tools::safeOutput($supplier['name']).'">'.Tools::safeOutput($supplier['name']).'</a></li>'.PHP_EOL;
+                        $supplierNode = self::createNode(BlocktopmenuNode::TYPE_MANUFACTURER, array(
+                            'link' => $link->getSupplierLink((int)$supplier['id_supplier'], $supplier['link_rewrite']),
+                            'name' => Tools::safeOutput($supplier['name']),
+                        ));
+                        $suppliersNode->addChild($supplierNode);
                     }
-                    $this->_menu .= '</ul>';
+                    $items[] = $suppliersNode;
+                    $this->_menu .= self::renderNode($suppliersNode);
                     break;
 
                 case 'SUP':
-                    $selected = ($this->page_name == 'supplier' && (Tools::getValue('id_supplier') == $id)) ? ' class="sfHover"' : '';
+                    $selected = $this->page_name == 'supplier' && Tools::getValue('id_supplier') == $id;
                     $supplier = new Supplier((int)$id, (int)$id_lang);
                     if (!is_null($supplier->id)) {
                         $link = new Link;
-                        $this->_menu .= '<li'.$selected.'><a href="'.Tools::HtmlEntitiesUTF8($link->getSupplierLink((int)$id, $supplier->link_rewrite)).'" title="'.$supplier->name.'">'.$supplier->name.'</a></li>'.PHP_EOL;
+                        $supplierNode = self::createNode(BlocktopmenuNode::TYPE_MANUFACTURER, array(
+                            'link' => Tools::HtmlEntitiesUTF8($link->getSupplierLink((int)$id, $supplier->link_rewrite)),
+                            'name' => Tools::safeOutput($supplier->name),
+                        ));
+                        $items[] = $supplierNode;
+                        $this->_menu .= self::renderNode($supplierNode);
                     }
                     break;
 
                 case 'SHOP':
-                    $selected = ($this->page_name == 'index' && ($this->context->shop->id == $id)) ? ' class="sfHover"' : '';
+                    $selected = $this->page_name == 'index' && $this->context->shop->id == $id;
                     $shop = new Shop((int)$id);
                     if (Validate::isLoadedObject($shop)) {
                         $link = new Link;
-                        $this->_menu .= '<li'.$selected.'><a href="'.Tools::HtmlEntitiesUTF8($shop->getBaseURL()).'" title="'.$shop->name.'">'.$shop->name.'</a></li>'.PHP_EOL;
+                        $shopNode = self::createNode(BlocktopmenuNode::TYPE_SHOP, array(
+                            'link' => Tools::HtmlEntitiesUTF8($shop->getBaseURL()),
+                            'name' => Tools::safeOutput($shop->name),
+                        ));
+                        $shopNode->setSelected($selected);
+                        $items[] = $shopNode;
+                        $this->_menu .= self::renderNode($shopNode);
                     }
                     break;
                 case 'LNK':
                     $link = MenuTopLinks::get((int)$id, (int)$id_lang, (int)$id_shop);
-                    if (count($link)) {
+                    if (count($link) == 1) {
                         if (!isset($link[0]['label']) || ($link[0]['label'] == '')) {
                             $default_language = Configuration::get('PS_LANG_DEFAULT');
                             $link = MenuTopLinks::get($link[0]['id_linksmenutop'], $default_language, (int)Shop::getContextShopID());
                         }
-                        $this->_menu .= '<li><a href="'.Tools::HtmlEntitiesUTF8($link[0]['link']).'"'.(($link[0]['new_window']) ? ' onclick="return !window.open(this.href);"': '').' title="'.Tools::safeOutput($link[0]['label']).'">'.Tools::safeOutput($link[0]['label']).'</a></li>'.PHP_EOL;
+                        $linkNode = self::createNode(BlocktopmenuNode::TYPE_LINK, array(
+                            'link' => Tools::HtmlEntitiesUTF8($link[0]['link']),
+                            'name' => Tools::safeOutput($link[0]['label']),
+                            'new_window' => $link[0]['new_window'],
+                        ));
+                        $this->_menu .= self::renderNode($linkNode);
                     }
                     break;
             }
         }
+
+        $this->items = $items;
     }
 
     protected function generateCategoriesOption($categories, $items_to_skip = null)
@@ -590,93 +667,20 @@ class Blocktopmenu extends Module
         return $html;
     }
 
+    /**
+     * @deprecated
+     */
     protected function generateCategoriesMenu($categories, $is_children = 0)
     {
-        $html = '';
-
-        foreach ($categories as $key => $category) {
-            if ($category['level_depth'] > 1) {
-                $cat = new Category($category['id_category']);
-                $link = Tools::HtmlEntitiesUTF8($cat->getLink());
-            } else {
-                $link = $this->context->link->getPageLink('index');
-            }
-
-            /* Whenever a category is not active we shouldnt display it to customer */
-            if ((bool)$category['active'] === false) {
-                continue;
-            }
-
-            $html .= '<li'.(($this->page_name == 'category'
-                && (int)Tools::getValue('id_category') == (int)$category['id_category']) ? ' class="sfHoverForce"' : '').'>';
-            $html .= '<a href="'.$link.'" title="'.$category['name'].'">'.$category['name'].'</a>';
-
-            if (isset($category['children']) && !empty($category['children'])) {
-                $html .= '<ul>';
-                $html .= $this->generateCategoriesMenu($category['children'], 1);
-
-                if ((int)$category['level_depth'] > 1 && !$is_children) {
-                    $files = scandir(_PS_CAT_IMG_DIR_);
-
-                    if (count(preg_grep('/^'.$category['id_category'].'-([0-9])?_thumb.jpg/i', $files)) > 0) {
-                        $html .= '<li class="category-thumbnail">';
-
-                        foreach ($files as $file) {
-                            if (preg_match('/^'.$category['id_category'].'-([0-9])?_thumb.jpg/i', $file) === 1) {
-                                $html .= '<div><img src="'.$this->context->link->getMediaLink(_THEME_CAT_DIR_.$file)
-                                .'" alt="'.Tools::SafeOutput($category['name']).'" title="'
-                                .Tools::SafeOutput($category['name']).'" class="imgm" /></div>';
-                            }
-                        }
-
-                        $html .= '</li>';
-                    }
-                }
-
-                $html .= '</ul>';
-            }
-
-            $html .= '</li>';
-        }
-
-        return $html;
+        return '';
     }
 
+    /**
+     * @deprecated
+     */
     protected function getCMSMenuItems($parent, $depth = 1, $id_lang = false)
     {
-        $id_lang = $id_lang ? (int)$id_lang : (int)Context::getContext()->language->id;
-
-        if ($depth > 3) {
-            return;
-        }
-
-        $categories = $this->getCMSCategories(false, (int)$parent, (int)$id_lang);
-        $pages = $this->getCMSPages((int)$parent);
-
-        if (count($categories) || count($pages)) {
-            $this->_menu .= '<ul>';
-
-            foreach ($categories as $category) {
-                $cat = new CMSCategory((int)$category['id_cms_category'], (int)$id_lang);
-
-                $this->_menu .= '<li>';
-                $this->_menu .= '<a href="'.Tools::HtmlEntitiesUTF8($cat->getLink()).'">'.$category['name'].'</a>';
-                $this->getCMSMenuItems($category['id_cms_category'], (int)$depth + 1);
-                $this->_menu .= '</li>';
-            }
-
-            foreach ($pages as $page) {
-                $cms = new CMS($page['id_cms'], (int)$id_lang);
-                $links = $cms->getLinks((int)$id_lang, array((int)$cms->id));
-
-                $selected = ($this->page_name == 'cms' && ((int)Tools::getValue('id_cms') == $page['id_cms'])) ? ' class="sfHoverForce"' : '';
-                $this->_menu .= '<li '.$selected.'>';
-                $this->_menu .= '<a href="'.$links[0]['link'].'">'.$cms->meta_title.'</a>';
-                $this->_menu .= '</li>';
-            }
-
-            $this->_menu .= '</ul>';
-        }
+        return '';
     }
 
     protected function getCMSOptions($parent = 0, $depth = 1, $id_lang = false, $items_to_skip = null, $id_shop = false)
@@ -735,6 +739,7 @@ class Blocktopmenu extends Module
 
             $this->smarty->assign('MENU_SEARCH', Configuration::get('MOD_BLOCKTOPMENU_SEARCH', null, $shop_group_id, $shop_id));
             $this->smarty->assign('MENU', $this->_menu);
+            $this->smarty->assign('items', $this->items);
             $this->smarty->assign('this_path', $this->_path);
         }
 
@@ -1357,5 +1362,102 @@ class Blocktopmenu extends Module
         $helper->currentIndex = AdminController::$currentIndex.'&configure='.$this->name;
 
         return $helper->generateList($links, $fields_list);
+    }
+
+    private function createCategoryNode(array $category, $addThumbnails = false)
+    {
+        if (!$category['active']) {
+            return;
+        }
+
+        if ($category['level_depth'] > 1) {
+            $cat = new Category($category['id_category']);
+            $link = Tools::HtmlEntitiesUTF8($cat->getLink());
+        } else {
+            $link = $this->context->link->getPageLink('index');
+        }
+
+        $categoryNode = self::createNode(BlocktopmenuNode::TYPE_CATEGORY, array(
+            'link' => $link,
+            'name' => $category['name'],
+        ));
+
+        $selected = $this->page_name == 'category' && Tools::getValue('id_category') == $category['id_category'];
+        $categoryNode->setSelected($selected);
+
+        if (isset($category['children']) && !empty($category['children'])) {
+            foreach ($category['children'] as $child) {
+                if ($childNode = $this->createCategoryNode($child)) {
+                    $categoryNode->addChild($childNode);
+                }
+            }
+            if ($addThumbnails && $category['level_depth'] > 1) {
+                $images = array();
+                $files = scandir(_PS_CAT_IMG_DIR_);
+                foreach ($files as $file) {
+                    if (preg_match('/^'.$category['id_category'].'-([0-9])?_thumb.jpg/i', $file) === 1) {
+                        $images[] = array(
+                            'src' => $this->context->link->getMediaLink(_THEME_CAT_DIR_.$file),
+                            'alt' => Tools::SafeOutput($category['name']),
+                            'title' => Tools::SafeOutput($category['name']),
+                        );
+                    }
+                }
+                if (!empty($images)) {
+                    $thumbnailsNode = self::createNode(BlocktopmenuNode::TYPE_CATEGORY_THUMBNAILS, array(
+                        'images' => $images,
+                    ));
+                    $categoryNode->addChild($childNode);
+                }
+            }
+        }
+
+        return $categoryNode;
+    }
+
+    private function createCmsCategoryNode(CMSCategory $cmsCategory)
+    {
+        $cmsCategoryNode = self::createNode(BlocktopmenuNode::TYPE_CMS_CATEGORY, array(
+            'link' => Tools::HtmlEntitiesUTF8($cmsCategory->getLink()),
+            'name' => $cmsCategory->name,
+        ));
+
+        $id_lang = Context::getContext()->language->id;
+
+        $categories = $this->getCMSCategories(false, $cmsCategory->id, $id_lang);
+        $pages = $this->getCMSPages($cmsCategory->id);
+
+        if (count($categories) || count($pages)) {
+            foreach ($categories as $category) {
+                $cmsSubCategory = new CMSCategory($category['id_cms_category'], $id_lang);
+                $cmsCategoryNode->addChild($this->createCmsCategoryNode($cmsSubCategory));
+            }
+            foreach ($pages as $page) {
+                $cms = new CMS($page['id_cms'], $id_lang);
+                $links = $cms->getLinks($id_lang, array($cms->id));
+                $selected = $this->page_name == 'cms' && Tools::getValue('id_cms') == $page['id_cms'];
+                $cmsNode = self::createNode(BlocktopmenuNode::TYPE_CMS, array(
+                    'link' => Tools::HtmlEntitiesUTF8($links[0]['link']),
+                    'name' => $cms->meta_title,
+                ));
+                $cmsNode->setSelected($selected);
+                $cmsCategoryNode->addChild($cmsNode);
+            }
+        }
+
+        return $cmsCategoryNode;
+    }
+
+    private static function renderNode(BlocktopmenuNode $node)
+    {
+        $visitor = new SuperfishNodeVisitor();
+        $visitor->visit($node);
+
+        return (string) $visitor;
+    }
+
+    private static function createNode($type, array $data = array())
+    {
+        return new BlocktopmenuNode($type, $data);
     }
 }

--- a/blocktopmenu.tpl
+++ b/blocktopmenu.tpl
@@ -1,24 +1,43 @@
-{if $MENU != ''}
-	
-	<!-- Menu -->
-	<div class="sf-contener clearfix">
-		<ul class="sf-menu clearfix">
-			{$MENU}
-			{if $MENU_SEARCH}
-				<li class="sf-search noBack" style="float:right">
-					<form id="searchbox" action="{$link->getPageLink('search')|escape:'html'}" method="get">
-						<p>
-							<input type="hidden" name="controller" value="search" />
-							<input type="hidden" value="position" name="orderby"/>
-							<input type="hidden" value="desc" name="orderway"/>
-							<input type="text" name="search_query" value="{if isset($smarty.get.search_query)}{$smarty.get.search_query|escape:'html':'UTF-8'}{/if}" />
-						</p>
-					</form>
-				</li>
-			{/if}
+{function name="blocktopmenu_menu" items=array()}
+	{foreach $items as $item}
+	<li {if $item.selected}class="sfHover"{/if}>
+		<a href="{$item.data.link}" title="{$item.data.name}">{$item.data.name}</a>
+		{if $item|count > 0}
+		<ul>
+			{blocktopmenu_menu items=$item.children}
+			{if $item.type == 'category-thumbnails'}
+            <li class="category-thumbnail">
+				{foreach $item.images as $image}
+				<div>
+					<img class="imgm" src="{$image.src}" alt="{$image.alt}" title="{$image.title}" />
+				</div>
+				{/foreach}
+			</li>
+            {/if}
 		</ul>
-	</div>
-	<div class="sf-right">&nbsp;</div>
+		{/if}
+	</li>
+	{/foreach}
+{/function}
 
-	<!--/ Menu -->
+{if $items|count > 0}
+<div class="sf-contener clearfix">
+	<ul class="sf-menu clearfix">
+		{$MENU}
+		{* {blocktopmenu_menu items=$items} *}
+		{if $MENU_SEARCH}
+		<li class="sf-search noBack" style="float:right">
+			<form id="searchbox" action="{$link->getPageLink('search')|escape:'html'}" method="get">
+				<p>
+					<input type="hidden" name="controller" value="search" />
+					<input type="hidden" value="position" name="orderby"/>
+					<input type="hidden" value="desc" name="orderway"/>
+					<input type="text" name="search_query" value="{if isset($smarty.get.search_query)}{$smarty.get.search_query|escape:'html':'UTF-8'}{/if}" />
+				</p>
+			</form>
+		</li>
+		{/if}
+	</ul>
+</div>
+<div class="sf-right">&nbsp;</div>
 {/if}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
   "require": {
     "php": ">=5.3.2"
   },
+  "require-dev": {
+    "phpunit/phpunit": "~4.5"
+  },
   "config": {
     "preferred-install": "dist"
   },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit>
+    <testsuites>
+        <testsuite name="blocktopmenu">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/BlocktopMenuNodeVisitor.php
+++ b/src/BlocktopMenuNodeVisitor.php
@@ -1,0 +1,6 @@
+<?php
+
+interface BlocktopMenuNodeVisitor
+{
+    public function visit(BlocktopMenuNode $node);
+}

--- a/src/BlocktopmenuNode.php
+++ b/src/BlocktopmenuNode.php
@@ -1,0 +1,102 @@
+<?php
+
+class BlocktopmenuNode implements ArrayAccess, Countable, IteratorAggregate
+{
+    const TYPE_CATEGORY = 'category';
+    const TYPE_CATEGORY_THUMBNAILS = 'category-thumbnails';
+    const TYPE_PRODUCT = 'product';
+    const TYPE_MANUFACTURERS = 'manufacturers';
+    const TYPE_MANUFACTURER = 'manufacturer';
+    const TYPE_SUPPLIERS = 'suppliers';
+    const TYPE_SUPPLIER = 'supplier';
+    const TYPE_CMS = 'cms';
+    const TYPE_CMS_CATEGORY = 'cms-category';
+    const TYPE_SHOP = 'shop';
+    const TYPE_LINK = 'link';
+
+    private $type;
+    private $selected = false;
+    private $data = array();
+    private $children = array();
+
+    public function __construct($type, array $data = array())
+    {
+        $this->type = $type;
+        $this->data = $data;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getData($name)
+    {
+        return isset($this->data[$name]) ? $this->data[$name] : null;
+    }
+
+    public function addChild(BlocktopmenuNode $node)
+    {
+        $this->children[] = $node;
+
+        return $this;
+    }
+
+    public function setSelected($selected = true)
+    {
+        $this->selected = $selected;
+
+        return $this;
+    }
+
+    public function isSelected()
+    {
+        return $this->selected;
+    }
+
+    public function getChildren()
+    {
+        return $this->children;
+    }
+
+    public function offsetExists($offset)
+    {
+        return null !== $this->offsetGet($offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        switch ($offset) {
+            case 'selected' :
+                return $this->selected;
+            case 'children' :
+                return $this->children;
+            case 'data' :
+                return $this->data;
+                break;
+            case 'type' :
+                return $this->type;
+                break;
+        }
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        // Read only
+    }
+
+    public function offsetUnset($offset)
+    {
+        // Read only
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->children);
+    }
+
+    public function count()
+    {
+        return count($this->children);
+    }
+}

--- a/src/SuperfishNodeVisitor.php
+++ b/src/SuperfishNodeVisitor.php
@@ -1,0 +1,51 @@
+<?php
+
+class SuperfishNodeVisitor implements BlocktopMenuNodeVisitor
+{
+    private $output;
+
+    public function reset()
+    {
+        $this->output = '';
+    }
+
+    public function visit(BlocktopMenuNode $node)
+    {
+        $cssClasses = array();
+        if ($node->isSelected()) {
+            $cssClasses[] = 'sfHover';
+        }
+        if ($node->getType() === BlocktopMenuNode::TYPE_CATEGORY_THUMBNAILS) {
+            $cssClasses[] = 'category-thumbnail';
+        }
+
+        $this->output .= '<li'.(!empty($cssClasses) ? ' class="'.implode(' ', $cssClasses).'"' : '').'>';
+        switch ($node->getType()) {
+            case BlocktopMenuNode::TYPE_CATEGORY_THUMBNAILS:
+                foreach ($node->getData('images') as $image) {
+                    $this->output .= '<div><img src="'.$image['src'].'" alt="'.$image['alt'].'" title="'.$image['title'].'" class="imgm" /></div>';
+                }
+                break;
+            case BlocktopMenuNode::TYPE_LINK:
+                $newWindow = true === $node->getData('new_window');
+                $this->output .= '<a href="'.$node->getData('link').'" title="'.$node->getData('name').'"'.($newWindow ? ' onclick="return !window.open(this.href);"' : '').'>'.$node->getData('name').'</a>';
+                break;
+            default :
+                $this->output .= '<a href="'.$node->getData('link').'" title="'.$node->getData('name').'">'.$node->getData('name').'</a>';
+        }
+
+        if (count($node) > 0) {
+            $this->output .= '<ul>';
+            foreach ($node as $childNode) {
+                $this->visit($childNode);
+            }
+            $this->output .= '</ul>';
+        }
+        $this->output .= '</li>';
+    }
+
+    public function __toString()
+    {
+        return $this->output;
+    }
+}

--- a/tests/BlocktopmenuNodeTest.php
+++ b/tests/BlocktopmenuNodeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once dirname(__FILE__).'/../src/BlocktopmenuNode.php';
+
+class BlocktopmenuNodeTest extends PHPUnit_Framework_TestCase
+{
+    public function testClassIsCountableAndIterable()
+    {
+        $category = new BlocktopmenuNode(BlocktopmenuNode::TYPE_CATEGORY);
+
+        $subCategory1 = new BlocktopmenuNode(BlocktopmenuNode::TYPE_CATEGORY);
+        $category->addChild($subCategory1);
+
+        $subCategory2 = new BlocktopmenuNode(BlocktopmenuNode::TYPE_CATEGORY);
+        $category->addChild($subCategory2);
+
+        $this->assertCount(2, $category);
+        $i = 0;
+        foreach ($category as $key => $subCategory) {
+            if ($key === 0) {
+                $this->assertSame($subCategory1, $subCategory);
+            }
+            if ($key === 1) {
+                $this->assertSame($subCategory2, $subCategory);
+            }
+            ++$i;
+        }
+        $this->assertEquals(2, $i);
+    }
+}

--- a/tests/SuperfishNodeVisitorTest.php
+++ b/tests/SuperfishNodeVisitorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+require_once dirname(__FILE__).'/../src/BlocktopmenuNode.php';
+require_once dirname(__FILE__).'/../src/BlocktopmenuNodeVisitor.php';
+require_once dirname(__FILE__).'/../src/SuperfishNodeVisitor.php';
+
+class SuperfishNodeVisitorTest extends PHPUnit_Framework_TestCase
+{
+    public function testVisitProductNode()
+    {
+        $visitor = new SuperfishNodeVisitor();
+
+        $node = new BlocktopmenuNode(BlocktopmenuNode::TYPE_PRODUCT, array(
+            'name' => 'Foo',
+            'link' => 'http://prestashop.com',
+        ));
+
+        $node->setSelected(false);
+        $visitor->visit($node);
+        $this->assertEquals((string) $visitor, '<li><a href="http://prestashop.com" title="Foo">Foo</a></li>');
+
+        $visitor->reset();
+        $node->setSelected(true);
+        $visitor->visit($node);
+        $this->assertEquals((string) $visitor, '<li class="sfHover"><a href="http://prestashop.com" title="Foo">Foo</a></li>');
+    }
+
+    public function testVisitLinkNode()
+    {
+        $visitor = new SuperfishNodeVisitor();
+
+        $node = new BlocktopmenuNode(BlocktopmenuNode::TYPE_LINK, array(
+            'name' => 'Foo',
+            'link' => 'http://prestashop.com',
+            'new_window' => true
+        ));
+
+        $node->setSelected(false);
+        $visitor->visit($node);
+        $this->assertEquals((string) $visitor, '<li><a href="http://prestashop.com" title="Foo" onclick="return !window.open(this.href);">Foo</a></li>');
+    }
+
+    public function testVisitCategoryNode()
+    {
+        $category = new BlocktopmenuNode(BlocktopmenuNode::TYPE_CATEGORY, array(
+            'name' => 'Foo',
+            'link' => 'http://foo.prestashop.com',
+        ));
+
+        $subCategory1 = new BlocktopmenuNode(BlocktopmenuNode::TYPE_CATEGORY, array(
+            'name' => 'Bar',
+            'link' => 'http://bar.prestashop.com',
+        ));
+        $category->addChild($subCategory1);
+
+        $subCategory2 = new BlocktopmenuNode(BlocktopmenuNode::TYPE_CATEGORY, array(
+            'name' => 'Baz',
+            'link' => 'http://baz.prestashop.com',
+        ));
+        $category->addChild($subCategory2);
+
+        $thumbnails = new BlocktopmenuNode(BlocktopmenuNode::TYPE_CATEGORY_THUMBNAILS, array(
+            'images' => array(
+                array(
+                    'src' => 'http://prestashop.com/logo.jpg',
+                    'alt' => 'PrestaShop',
+                    'title' => 'PrestaShop',
+                ),
+                array(
+                    'src' => 'http://prestashop.com/logo.jpg',
+                    'alt' => 'PrestaShop',
+                    'title' => 'PrestaShop',
+                ),
+            ),
+        ));
+        $category->addChild($thumbnails);
+
+        $visitor = new SuperfishNodeVisitor();
+        $visitor->visit($category);
+
+        $expected = <<<EXPECTED
+        <li>
+            <a href="http://foo.prestashop.com" title="Foo">Foo</a>
+            <ul>
+                <li><a href="http://bar.prestashop.com" title="Bar">Bar</a></li>
+                <li><a href="http://baz.prestashop.com" title="Baz">Baz</a></li>
+                <li class="category-thumbnail">
+                    <div><img src="http://prestashop.com/logo.jpg" alt="PrestaShop" title="PrestaShop" class="imgm" /></div>
+                    <div><img src="http://prestashop.com/logo.jpg" alt="PrestaShop" title="PrestaShop" class="imgm" /></div>
+                </li>
+            </ul>
+        </li>
+EXPECTED;
+
+        $this->assertEquals((string) $visitor, str_replace(array(PHP_EOL, '  '), array('', ''), $expected));
+    }
+}


### PR DESCRIPTION
Hello, 

Reopening PR #42 on the dev branch

As agreed with @djfm, I sort of backported this branch to be retrocompatible: https://github.com/PrestaShop/blocktopmenu/commits/feat/starter-theme

This introduces a composite data structure for the menu items: now theme developers can completely redefine the HTML structure of the menu using Smarty. 

```smarty
{function name="blocktopmenu_menu" items=array()}
	{foreach $items as $item}
	<li {if $item.selected}class="sfHover"{/if}>
		<a href="{$item.data.link}" title="{$item.data.name}">{$item.data.name}</a>
		{if $item|count > 0}
		<ul>
			{blocktopmenu_menu items=$item.children}
			{if $item.type == 'category-thumbnails'}
            <li class="category-thumbnail">
				{foreach $item.images as $image}
				<div>
					<img class="imgm" src="{$image.src}" alt="{$image.alt}" title="{$image.title}" />
				</div>
				{/foreach}
			</li>
            {/if}
		</ul>
		{/if}
	</li>
	{/foreach}
{/function}

<ul>
    {blocktopmenu_menu items=$items}
</ul>
```

To keep things retrocompatible, the `$MENU` variable is still assigned, using `SuperfishNodeVisitor` to replicate the legacy behavior. 

I still need to make a few adjustments, but please start reviewing. 