### PR TITLE
FO: Get only active nested categories

### DIFF
--- a/blocktopmenu.php
+++ b/blocktopmenu.php
@@ -477,7 +477,7 @@ class Blocktopmenu extends Module
 
             switch (substr($item, 0, strlen($value[1]))) {
                 case 'CAT':
-                    $this->_menu .= $this->generateCategoriesMenu(Category::getNestedCategories($id, $id_lang, false, $this->user_groups));
+                    $this->_menu .= $this->generateCategoriesMenu(Category::getNestedCategories($id, $id_lang, true, $this->user_groups));
                     break;
 
                 case 'PRD':


### PR DESCRIPTION
An arrow is shown in the top menu when a category has subcategory hidden.