### PR TITLE
Fixing wrong "int" casting on label and link

### DIFF
--- a/blocktopmenu.php
+++ b/blocktopmenu.php
@@ -930,7 +930,7 @@ class Blocktopmenu extends Module
             foreach ($lang as $l) {
                 Db::getInstance()->execute('
 					INSERT IGNORE INTO '._DB_PREFIX_.'linksmenutop_lang (id_linksmenutop, id_lang, id_shop, label, link)
-					VALUES ('.(int)$link['new_id_linksmenutop'].', '.(int)$l['id_lang'].', '.(int)$params['new_id_shop'].', '.(int)$l['label'].', '.(int)$l['link'].' )');
+					VALUES ('.(int)$link['new_id_linksmenutop'].', '.(int)$l['id_lang'].', '.(int)$params['new_id_shop'].', \''.pSQL($l['label']).'\', \''.$l['link'].'\' )');
             }
         }
     }


### PR DESCRIPTION
When creating a new shop, on actionShopDataDuplication, the "label" and "link" fields were set to 0 because of a (int) casting